### PR TITLE
fixed issue in qepcad-api-call where boolean constants in the input f…

### DIFF
--- a/interpreter/src/formula/formula.h
+++ b/interpreter/src/formula/formula.h
@@ -33,7 +33,7 @@ class TFormObj : public GC_Obj
 {
 public:
   virtual ~TFormObj() { }
-  virtual PolyManager* getPolyManagerPtr() { return 0; }
+  virtual PolyManager* getPolyManagerPtr() { return NULL; }
   virtual void write(bool flag = false) = 0; // writes to the current saclib context!
   virtual void apply(TFPolyFun &F) = 0;
   virtual VarSet getVars() = 0;
@@ -259,7 +259,10 @@ public:
   int size() const { return conjuncts.size(); }
   PolyManager* getPolyManagerPtr()
   {
-    return conjuncts.empty() ? NULL : (*conjuncts.begin())->getPolyManagerPtr();
+    PolyManager* res = NULL;
+    for(auto itr = conjuncts.begin(); res == NULL && itr != conjuncts.end(); ++itr)
+      res = (*itr)->getPolyManagerPtr();
+    return res;
   }
   VarSet getVars();
   TFormRef negate();
@@ -300,7 +303,10 @@ public:
   VarSet getVars();
   PolyManager* getPolyManagerPtr()
   {
-    return disjuncts.empty() ? NULL : (*disjuncts.begin())->getPolyManagerPtr();
+    PolyManager* res = NULL;
+    for(auto itr = disjuncts.begin(); res == NULL && itr != disjuncts.end(); ++itr)
+      res = (*itr)->getPolyManagerPtr();
+    return res;
   }
   TFormRef negate();
   int constValue() { return size() == 0 ? FALSE : -1; }

--- a/interpreter/src/shell/qepcad-inter/qepcad-api.cpp
+++ b/interpreter/src/shell/qepcad-inter/qepcad-api.cpp
@@ -94,6 +94,13 @@ namespace tarski {
     SRef res;
     try {
       TFormRef T = args[0]->tar()->val;
+
+      // Do basic normalization to get rid of boolean constants, which qepcad
+      // doesn't understand.
+      RawNormalizer R(defaultNormalizer);
+      R(T);
+      T = R.getRes();
+
       // Bail out if this is already a constant
       { int tmp = T->constValue(); if (tmp != -1) { return new TarObj(new TConstObj(tmp)); } }
       char formType = 'E'; // Default!


### PR DESCRIPTION
…ormula caused problems.  ultimately, I just 'normalize' prior to calling qepcad so the boolean constants get simplified away.  however, I also fixed a but in write for qepcad where the getPolyManagerPtr could fail if the first element of an AND or OR was a constant rather than an atom.